### PR TITLE
css file to select and style some of the html tags from the remarkable npm module #69

### DIFF
--- a/styles/markdownstyle.css
+++ b/styles/markdownstyle.css
@@ -1,0 +1,99 @@
+.container {
+  width: 75%;
+  min-width: 450px;
+  margin: 0 auto;
+  text-align: justify;
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, freesans, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+}
+
+h1 {
+  color: #4a4a4a;
+  margin: 0 auto;
+  font-size: 6em;
+  font-family: serif;
+}
+
+h2 {
+  color: #4a4a4a;
+  margin: 0 auto;
+  font-size: 5.5em;
+  font-family: serif;
+}
+
+h3 {
+  color: #4a4a4a;
+  margin: 0 auto;
+  font-size: 5em;
+  font-family: serif;
+}
+
+h4 {
+  color: #4a4a4a;
+  margin: 0 auto;
+  font-size: 4.5em;
+  font-family: serif;
+}
+
+h5 {
+  color: #4a4a4a;
+  margin: 0 auto;
+  font-size: 4em;
+  font-family: serif;
+}
+
+h6 {
+  color: #4a4a4a;
+  margin: 0 auto;
+  font-size: 3.5em;
+  font-family: serif;
+}
+
+li {
+  line-height: 30px;
+}
+
+p {
+  line-height: 30px;
+}
+
+blockquote {
+  background-color: #d8deea;
+  border: 1px solid #c6d1e7;
+  border-radius: 9px;
+  padding-top: 2px;
+  padding-bottom: 2px;
+  padding-left: 16px;
+  padding-right: 16px;
+}
+
+strong {
+  font-size: 18px;
+  font-weight: 3000;
+}
+
+code {
+  background-color: #eee;
+  font-family: monospace;
+}
+/* The next three are the classes that the
+remarkable module produces when code blocks
+include '```js' for 'javascript code */
+
+.hljs-keyword {
+      color: #859900;
+}
+.hljs-built_in{
+  color: #268bd2
+}
+.hljs-number {
+  color: #2aa198
+}
+ pre {
+    line-height: 135%;
+    background-color: #eee;
+    border: 1px solid #ddd;
+    padding-left: 6px;
+    padding-right: 2px;
+    padding-bottom: 5px;
+    padding-top: 5px;
+}


### PR DESCRIPTION
some markdown features that get converted to tags do need some styling, for instance <blockquote> and <code> this file contains some css to address some of these.